### PR TITLE
Improve Get-DataverseAuthToken function with better error handling

### DIFF
--- a/src/PipeDream/scripts/Get-DataverseAuthToken.ps1
+++ b/src/PipeDream/scripts/Get-DataverseAuthToken.ps1
@@ -18,31 +18,58 @@ function Get-DataverseAuthToken {
     .PARAMETER ClientSecret
     The client secret of the application.
 
+    .OUTPUTS
+    PSCustomObject containing the following properties:
+    - AccessToken: The access token to use in API calls
+    - TokenType: The token type (typically "Bearer")
+    - ExpiresIn: Token lifespan in seconds
+    - ExpiresAt: DateTime when the token expires (in UTC)
+    - Resource: Resource the token is valid for
+
     .EXAMPLE
     $token = Get-DataverseAuthToken -TenantId '00000000-0000-0000-0000-000000000000' -EnvironmentUrl 'https://your-org.crm.dynamics.com' -ClientId '00000000-0000-0000-0000-000000000000' -ClientSecret 'your-client-secret'
+
+    .EXAMPLE
+    # Get token and use it in a subsequent API call
+    $token = Get-DataverseAuthToken -TenantId '00000000-0000-0000-0000-000000000000' -EnvironmentUrl 'https://your-org.crm.dynamics.com' -ClientId '00000000-0000-0000-0000-000000000000' -ClientSecret 'your-client-secret'
+    
+    $headers = @{
+        "Authorization" = "$($token.TokenType) $($token.AccessToken)"
+        "Content-Type" = "application/json"
+    }
+    $apiUrl = "$($EnvironmentUrl)/api/data/v9.1/accounts"
+    Invoke-RestMethod -Method Get -Uri $apiUrl -Headers $headers
     #>
-
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
     param (
-
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$TenantId,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidatePattern('^https?://')]
         [string]$EnvironmentUrl,
     
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$ClientId,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$ClientSecret
     )
 
     begin {
+        Write-Verbose "Starting authentication process for Dataverse environment: $EnvironmentUrl"
+        
         # Ensure URL has no trailing slash
         $resource = $EnvironmentUrl.TrimEnd('/')
         
         # Azure AD OAuth endpoint
         $oauthUrl = "https://login.microsoftonline.com/$TenantId/oauth2/token"
+        Write-Verbose "Using OAuth URL: $oauthUrl"
     }
 
     process {
@@ -54,23 +81,36 @@ function Get-DataverseAuthToken {
                 resource      = $resource
                 grant_type    = "client_credentials"
             }
+            Write-Verbose "Requesting token for resource: $resource"
 
             # Get the OAuth token
-            $response = Invoke-RestMethod -Method Post -Uri $oauthUrl -Body $body -ContentType "application/x-www-form-urlencoded"
+            $response = Invoke-RestMethod -Method Post -Uri $oauthUrl -Body $body -ContentType "application/x-www-form-urlencoded" -ErrorAction Stop
+            
+            Write-Verbose "Token acquired successfully. Token expires in $($response.expires_in) seconds"
+
+            # Calculate expiration time
+            $expirationTime = (Get-Date).AddSeconds($response.expires_in).ToUniversalTime()
+            $expirationTimeString = $expirationTime.ToString("yyyy-MM-ddTHH:mm:ssZ")
 
             # Create a custom token object with useful properties
             $token = [PSCustomObject]@{
                 AccessToken = $response.access_token
                 TokenType   = $response.token_type
                 ExpiresIn   = $response.expires_in
-                ExpiresAt   = (Get-Date).AddSeconds($response.expires_in).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+                ExpiresAt   = $expirationTimeString
                 Resource    = $response.resource
             }
 
+            Write-Verbose "Token expires at: $expirationTimeString"
             return $token
         }
+        catch [System.Net.WebException] {
+            Write-Error "Failed to connect to authentication service. Please check your network connection and the environment URL."
+            throw "Authentication failed: $_"
+        }
         catch {
-            throw $_
+            Write-Error "Authentication failed. Please verify your credentials and tenant information."
+            throw "Authentication error: $_"
         }
     }
 }


### PR DESCRIPTION
## Changes to Get-DataverseAuthToken.ps1

- Added `[CmdletBinding()]` attribute to enable advanced function features like `-Verbose` support
- Added `[OutputType([PSCustomObject])]` to document the return type
- Added parameter validation using `ValidateNotNullOrEmpty()` for all parameters
- Added URL validation with `ValidatePattern('^https?://')` for the EnvironmentUrl parameter
- Added detailed documentation about output object properties in the comment-based help
- Added a second usage example showing how to use the token in a REST API call
- Added verbose logging for better troubleshooting capabilities
- Improved error handling with specific error messages for different failure scenarios
- Added explicit error action with `ErrorAction Stop` for better error flow control
- Improved token expiration calculation and formatting
- Enhanced code formatting and consistency