### PR TITLE
Set environment for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: PowerShellGallery
     steps:
       - uses: actions/checkout@v4
       - name: Publish to PowerShell Gallery


### PR DESCRIPTION
Added the 'PowerShellGallery' environment to the publish job in the GitHub Actions workflow to enable environment-specific features and controls.