### PR TITLE
Enhance Get-UrlFromAccessToken: robust audience parsing & normalization

### DIFF
--- a/src/PipeDream/Private/Get-UrlFromAccessToken.ps1
+++ b/src/PipeDream/Private/Get-UrlFromAccessToken.ps1
@@ -3,12 +3,14 @@ function Get-UrlFromAccessToken {
     .SYNOPSIS
         Extracts the URL from an access token.
     .DESCRIPTION
-        The Get-UrlFromAccessToken function extracts the audience (aud) claim from a JWT access token,
-        which typically contains the resource URL.
+        Extract the Dataverse environment base URL from the 'aud' (audience) claim of a JWT access token.
+        Robustly supports string or array 'aud' values, normalizes the result to a canonical
+        https://<host> form (lowercase host, no path/query, no trailing slash). Returns $null on any
+        parse/validation failure – no throws – to keep callers resilient.
     .PARAMETER AccessToken
         The authentication token string (access token) obtained from Get-DataverseAuthToken.
     .OUTPUTS
-        System.String. Returns the URL extracted from the token or $null if extraction fails.
+        System.String. Normalized https://<host> URL or $null if extraction/validation fails.
     .EXAMPLE
         $url = Get-UrlFromAccessToken -AccessToken $authResult.AccessToken
     .NOTES
@@ -20,7 +22,7 @@ function Get-UrlFromAccessToken {
     )
 
     try {
-        # Split the JWT token and decode the payload (middle part)
+    # Split the JWT token and decode the payload (middle part)
         $tokenParts = $AccessToken.Split('.')
         if ($tokenParts.Count -ne 3) {
             Write-Verbose "Invalid token format. Expected JWT format with 3 parts."
@@ -39,15 +41,42 @@ function Get-UrlFromAccessToken {
         $payloadJson = [System.Text.Encoding]::UTF8.GetString($payloadBytes)
         $tokenPayload = $payloadJson | ConvertFrom-Json
 
-        # Extract the audience claim
-        if ($tokenPayload.aud) {
-            Write-Verbose "Extracted URL from token: $($tokenPayload.aud)"
-            return $tokenPayload.aud
+        # Extract & normalize the audience claim.
+        $audValues = @()
+        if ($null -ne $tokenPayload.aud) {
+            if ($tokenPayload.aud -is [System.Array]) {
+                $audValues = @($tokenPayload.aud)
+            }
+            else {
+                $audValues = @($tokenPayload.aud)
+            }
         }
-        else {
+        if (-not $audValues -or $audValues.Count -eq 0) {
             Write-Verbose "Could not find 'aud' claim in the token payload."
             return $null
         }
+
+        foreach ($aud in $audValues) {
+            if (-not [string]::IsNullOrWhiteSpace($aud)) {
+                # Accept only potential https dynamics hosts
+                if ($aud -match '^https?://') {
+                    # Attempt to parse with System.Uri
+                    $uri = $null
+                    if ([System.Uri]::TryCreate($aud, [System.UriKind]::Absolute, [ref]$uri)) {
+                        if ($uri.Host -and $uri.Host -match '\.dynamics\.com$') {
+                            # Build canonical HTTPS URL with lowercase host only
+                            $builder = [System.UriBuilder]::new('https', $uri.Host.ToLowerInvariant())
+                            $normalized = $builder.Uri.AbsoluteUri.TrimEnd('/')
+                            Write-Verbose "Normalized audience '$aud' => '$normalized'"
+                            return $normalized
+                        }
+                    }
+                }
+            }
+        }
+
+        Write-Verbose "No valid Dataverse audience host found in 'aud' claim."
+        return $null
     }
     catch {
         Write-Verbose "Failed to extract URL from access token: $_"

--- a/tests/Private/Get-UrlFromAccessToken.Tests.ps1
+++ b/tests/Private/Get-UrlFromAccessToken.Tests.ps1
@@ -18,6 +18,34 @@ Describe "Get-UrlFromAccessToken (private)" {
         $result | Should -Be 'https://org.crm.dynamics.com'
     }
 
+    It "Normalizes audience with trailing slash and path" {
+        $result = InModuleScope PipeDream {
+            $aud = 'https://ORG.CRM.DYNAMICS.COM/api/data/v9.2/'
+            $header = (@{ alg = 'none'; typ = 'JWT' } | ConvertTo-Json -Compress)
+            $payload = (@{ aud = $aud } | ConvertTo-Json -Compress)
+            $toB64Url = { param($s) $b = [Text.Encoding]::UTF8.GetBytes($s); $x = [Convert]::ToBase64String($b); $x.TrimEnd('=') -replace '\+', '-' -replace '/', '_' }
+            $h = & $toB64Url $header
+            $p = & $toB64Url $payload
+            $token = "$h.$p.x"
+            Get-UrlFromAccessToken -AccessToken $token
+        }
+        $result | Should -Be 'https://org.crm.dynamics.com'
+    }
+
+    It "Selects first valid Dataverse host from aud array" {
+        $result = InModuleScope PipeDream {
+            $audArray = @('api://some-app-id','https://org.crm.dynamics.com/')
+            $header = (@{ alg = 'none'; typ = 'JWT' } | ConvertTo-Json -Compress)
+            $payload = (@{ aud = $audArray } | ConvertTo-Json -Compress)
+            $toB64Url = { param($s) $b = [Text.Encoding]::UTF8.GetBytes($s); $x = [Convert]::ToBase64String($b); $x.TrimEnd('=') -replace '\+', '-' -replace '/', '_' }
+            $h = & $toB64Url $header
+            $p = & $toB64Url $payload
+            $token = "$h.$p.x"
+            Get-UrlFromAccessToken -AccessToken $token
+        }
+        $result | Should -Be 'https://org.crm.dynamics.com'
+    }
+
     It "Returns $null when 'aud' is missing" {
         $result = InModuleScope PipeDream {
             $header = (@{ alg = 'none'; typ = 'JWT' } | ConvertTo-Json -Compress)
@@ -38,6 +66,19 @@ Describe "Get-UrlFromAccessToken (private)" {
 
     It "Returns $null on base64 decode error" {
         $result = InModuleScope PipeDream { Get-UrlFromAccessToken -AccessToken 'a.b.c' }
+        $null -eq $result | Should -BeTrue
+    }
+
+    It "Returns $null when aud is non-url string" {
+        $result = InModuleScope PipeDream {
+            $header = (@{ alg = 'none'; typ = 'JWT' } | ConvertTo-Json -Compress)
+            $payload = (@{ aud = 'not-a-url' } | ConvertTo-Json -Compress)
+            $toB64Url = { param($s) $b = [Text.Encoding]::UTF8.GetBytes($s); $x = [Convert]::ToBase64String($b); $x.TrimEnd('=') -replace '\+', '-' -replace '/', '_' }
+            $h = & $toB64Url $header
+            $p = & $toB64Url $payload
+            $token = "$h.$p.x"
+            Get-UrlFromAccessToken -AccessToken $token
+        }
         $null -eq $result | Should -BeTrue
     }
 }


### PR DESCRIPTION
Implements #24.

Summary
Enhances Get-UrlFromAccessToken to robustly parse and normalize the 'aud' claim from access tokens.

Key Changes
- Support 'aud' as string or array.
- Normalize to canonical https://<host> (lowercase host, no path/query, no trailing slash).
- Only accept *.dynamics.com hosts.
- Return $null on any parse/validation failure (no throw) preserving resilience.
- Added comprehensive unit tests covering:
  * Simple host
  * Trailing slash + path + mixed case normalization
  * Array with first valid dynamics host
  * Missing aud
  * Invalid token format
  * Base64 decode error
  * Non-url aud

Implementation Notes
Uses System.Uri.TryCreate then UriBuilder('https', host) to ensure HTTPS and strips path/query implicitly. Maintains existing Invoke-DataverseHttp behavior (will throw only if no URL derivable at higher layer).

All tests pass locally (7 tests added/updated).

Let me know if you'd like an additional smoke test variation.